### PR TITLE
add git derived version to html output

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,9 @@ language = 'en'
 #today = ''
 # Else, today_fmt is used as the format for a strftime call.
 #today_fmt = '%B %d, %Y'
+today_fmt = '%B %d, %Y'
+if release:
+    today_fmt += ' ({%s})' % version
 
 # List of documents that shouldn't be included in the build.
 #unused_docs = []
@@ -197,9 +200,7 @@ latex_show_pagerefs = True
 latex_documents = [
   ('index', 'PythonScientific.tex', ur'Python Scientific lecture notes',
    ur"""EuroScipy tutorial team \\\relax\normalfont Editors: Valentin Haenel, Emmanuelle Gouillart, Gaël Varoquaux"""
-   + r"\\\relax ~\\\relax http://scipy-lectures.github.com " \
-   + r"\\\relax ~\\\relax\\\relax ~\\\relax\\\relax ~\\\relax\\\relax ~\\\relax"\
-   + r"\normalfont Version: \ttfamily " + version,
+   + r"\\\relax ~\\\relax http://scipy-lectures.github.com",
    'manual'),
 ]
 

--- a/index.rst
+++ b/index.rst
@@ -124,5 +124,6 @@ _____
    intro/index.rst
    advanced/index.rst
 
-Generated from: '|version|'
-(output of ``git describe`` for `project repository <https://github.com/scipy-lectures/scipy-lecture-notes>`_)
+Version: |version| (output of ``git describe`` for `project repository`_)
+
+.. _`project repository`: https://github.com/scipy-lectures/scipy-lecture-notes


### PR DESCRIPTION
Please have a look at this attempt to add a git derived version number to the html output.
- It will break if its not in a git-repository. 
- Also i am not sure if the derivation should be done in conf.py?
- And any ideas to add this to the pdf-output would be appreciated.
