### PR TITLE
typo: missing spaces that break the list

### DIFF
--- a/intro/matplotlib/matplotlib.rst
+++ b/intro/matplotlib/matplotlib.rst
@@ -187,7 +187,7 @@ So far we have used properties for the lines.
 There are three possibilities to set them:
 
 1) as keyword arguments at creation time:
-``plot(x, linear, 'g:+', x, square, 'r--o')``.
+   ``plot(x, linear, 'g:+', x, square, 'r--o')``.
 
 2) with the function ``setp``: ``setp(line, color='g')``.
 


### PR DESCRIPTION
http://scipy-lectures.github.com/intro/matplotlib/matplotlib.html#properties
the 1st item of the list is not recognized, I guess it is because of the missing spaces.
