### PR TITLE
minor correction to clarify 'enumerate' is a built-in function

### DIFF
--- a/intro/language/control_flow.rst
+++ b/intro/language/control_flow.rst
@@ -198,7 +198,7 @@ item number.
     1 powerful
     2 readable
 
-* But, Python provides ``enumerate`` keyword for this::
+* But, Python provides a built-in function - ``enumerate`` - for this::
 
     >>> for index, item in enumerate(words):
     ...     print index, item


### PR DESCRIPTION
http://docs.python.org/3/library/functions.html#enumerate is a built-in, not a keyword
