### PR TITLE
Fixed color definition for matplotlib

### DIFF
--- a/intro/matplotlib/examples/plot_markers.py
+++ b/intro/matplotlib/examples/plot_markers.py
@@ -5,7 +5,7 @@ def marker(m, i):
     X = i * .5 * np.ones(11)
     Y = np.arange(11)
 
-    pl.plot(X, Y, color='None', lw=1, marker=m, ms=10, mfc=(.75, .75, 1, 1),
+    pl.plot(X, Y, lw=1, marker=m, ms=10, mfc=(.75, .75, 1, 1),
             mec=(0, 0, 1, 1))
     pl.text(.5 * i, 10.25, repr(m), rotation=90, fontsize=15, va='bottom')
 

--- a/intro/matplotlib/examples/plot_ticks.py
+++ b/intro/matplotlib/examples/plot_ticks.py
@@ -12,7 +12,7 @@ def tickline():
     ax.spines['bottom'].set_position(('data',0))
     ax.yaxis.set_ticks_position('none')
     ax.xaxis.set_minor_locator(pl.MultipleLocator(0.1))
-    ax.plot(np.arange(11), np.zeros(11), color='none')
+    ax.plot(np.arange(11), np.zeros(11))
     return ax
 
 locators = [


### PR DESCRIPTION
Matplotlib does not accept the String 'none' as color. If you leave the
parameter empty, the file compiles.
