### PR TITLE
Add client-side redirect to lectures.scientific-python.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
+html-scipy: export DOMAIN=scipy-lectures.org
+html-scipy: html
+
 cleandoctrees:
 	rm -rf build/doctrees
 
@@ -120,7 +123,9 @@ zip: clean html pdf
 	cp ScientificPythonLectures.pdf build/ ;
 	git archive -o build/scientific-python-lectures-source-$(TAG).zip --prefix scientific-python-lectures-$(TAG)/ $(TAG)
 
-install: cleandoctrees html pdf
+# This target is used to deploy to the old location: scipy-lectures.org
+# The site is now hosted via Netlify at https://lectures.scientific-python.org
+install: cleandoctrees html-scipy pdf
 	rm -rf build/scipy-lectures.github.com
 	cp ScientificPythonLectures.pdf ScientificPythonLectures-simple.pdf build/html/_downloads/
 	cd build/ && \

--- a/conf.py
+++ b/conf.py
@@ -10,6 +10,7 @@
 # serve to show the default.
 from datetime import date
 from subprocess import PIPE, Popen
+import os
 
 import sphinx_gallery
 from pygments import formatters
@@ -389,3 +390,9 @@ def setup(app):
 
     # Is this still used?
     app.add_css_file("https://unpkg.com/purecss@3.0.0/build/base-min.css")
+
+
+# Generate redirect on scipy-lectures.org
+domain = os.getenv("DOMAIN", "lectures.scientific-python.org")
+html_context = {"domain": domain}
+print(f"Building for domain: {domain}")

--- a/themes/scientific_python_lectures/layout.html
+++ b/themes/scientific_python_lectures/layout.html
@@ -2,6 +2,13 @@
 
 {% block extrahead %}
 {{ super() }}
+{% if domain == 'scipy-lectures.org' %}
+  {% if pagename.endswith('index') %}
+  <meta http-equiv="refresh" content="0; url=https://lectures.scientific-python.org/{{ pagename.rsplit('/', 1)[0] }}"}}>
+  {% else %}
+  <meta http-equiv="refresh" content="0; url=https://lectures.scientific-python.org/{{ pagename }}.html"}}>
+  {% endif %}
+{% endif %}
 <script defer data-domain="lectures.scientific-python.org" src="https://views.scientific-python.org/js/script.js"></script>
 {% endblock %}
 


### PR DESCRIPTION
Since we're hosting on GitHub Pages, we don't have the option of using a 301 Moved Permanently.

But this is a route recommended by Google:

https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls https://developers.google.com/search/docs/crawling-indexing/301-redirects#metarefresh