### PR TITLE
Replace use of scipy.fftpack with scipy.fft

### DIFF
--- a/intro/scipy/examples/plot_fftpack.py
+++ b/intro/scipy/examples/plot_fftpack.py
@@ -28,7 +28,7 @@ time_step = 0.02
 period = 5.0
 
 time_vec = np.arange(0, 20, time_step)
-sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * rng.randn(time_vec.size)
+sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * rng.normal(size=time_vec.size)
 
 plt.figure(figsize=(6, 5))
 plt.plot(time_vec, sig, label="Original signal")

--- a/intro/scipy/examples/plot_fftpack.py
+++ b/intro/scipy/examples/plot_fftpack.py
@@ -6,8 +6,8 @@ Plotting and manipulating FFTs for filtering
 Plot the power of the FFT of a signal and inverse FFT back to reconstruct
 a signal.
 
-This example demonstrate :func:`scipy.fftpack.fft`,
-:func:`scipy.fftpack.fftfreq` and :func:`scipy.fftpack.ifft`. It
+This example demonstrate :func:`scipy.fft.fft`,
+:func:`scipy.fft.fftfreq` and :func:`scipy.fft.ifft`. It
 implements a basic filter that is very suboptimal, and should not be
 used.
 
@@ -28,7 +28,7 @@ time_step = 0.02
 period = 5.0
 
 time_vec = np.arange(0, 20, time_step)
-sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * np.random.randn(time_vec.size)
+sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * rng.randn(time_vec.size)
 
 plt.figure(figsize=(6, 5))
 plt.plot(time_vec, sig, label="Original signal")
@@ -38,13 +38,13 @@ plt.plot(time_vec, sig, label="Original signal")
 ############################################################
 
 # The FFT of the signal
-sig_fft = sp.fftpack.fft(sig)
+sig_fft = sp.fft.fft(sig)
 
 # And the power (sig_fft is of complex dtype)
 power = np.abs(sig_fft) ** 2
 
 # The corresponding frequencies
-sample_freq = sp.fftpack.fftfreq(sig.size, d=time_step)
+sample_freq = sp.fft.fftfreq(sig.size, d=time_step)
 
 # Plot the FFT power
 plt.figure(figsize=(6, 5))
@@ -79,7 +79,7 @@ plt.setp(axes, yticks=[])
 
 high_freq_fft = sig_fft.copy()
 high_freq_fft[np.abs(sample_freq) > peak_freq] = 0
-filtered_sig = sp.fftpack.ifft(high_freq_fft)
+filtered_sig = sp.fft.ifft(high_freq_fft)
 
 plt.figure(figsize=(6, 5))
 plt.plot(time_vec, sig, label="Original signal")

--- a/intro/scipy/examples/solutions/plot_fft_image_denoise.py
+++ b/intro/scipy/examples/solutions/plot_fft_image_denoise.py
@@ -36,7 +36,7 @@ plt.title("Original image")
 ############################################################
 import scipy as sp
 
-im_fft = sp.fftpack.fft2(im)
+im_fft = sp.fft.fft2(im)
 
 # Show the results
 
@@ -88,7 +88,7 @@ plt.title("Filtered Spectrum")
 
 # Reconstruct the denoised image from the filtered spectrum, keep only the
 # real part for display.
-im_new = sp.fftpack.ifft2(im_fft2).real
+im_new = sp.fft.ifft2(im_fft2).real
 
 plt.figure()
 plt.imshow(im_new, plt.cm.gray)

--- a/intro/scipy/examples/solutions/plot_image_blur.py
+++ b/intro/scipy/examples/solutions/plot_image_blur.py
@@ -41,14 +41,14 @@ kernel = bump[:, np.newaxis] * bump[np.newaxis, :]
 #####################################################################
 
 # Padded fourier transform, with the same shape as the image
-# We use :func:`scipy.signal.fftpack.fft2` to have a 2D FFT
-kernel_ft = sp.fftpack.fft2(kernel, shape=img.shape[:2], axes=(0, 1))
+# We use :func:`scipy.signal.fft.fft2` to have a 2D FFT
+kernel_ft = sp.fft.fft2(kernel, s=img.shape[:2], axes=(0, 1))
 
 # convolve
-img_ft = sp.fftpack.fft2(img, axes=(0, 1))
+img_ft = sp.fft.fft2(img, axes=(0, 1))
 # the 'newaxis' is to match to color direction
 img2_ft = kernel_ft[:, :, np.newaxis] * img_ft
-img2 = sp.fftpack.ifft2(img2_ft, axes=(0, 1)).real
+img2 = sp.fft.ifft2(img2_ft, axes=(0, 1)).real
 
 # clip values to range
 img2 = np.clip(img2, 0, 1)

--- a/intro/scipy/examples/solutions/plot_image_blur.py
+++ b/intro/scipy/examples/solutions/plot_image_blur.py
@@ -41,7 +41,7 @@ kernel = bump[:, np.newaxis] * bump[np.newaxis, :]
 #####################################################################
 
 # Padded fourier transform, with the same shape as the image
-# We use :func:`scipy.signal.fft.fft2` to have a 2D FFT
+# We use :func:`scipy.fft.fft2` to have a 2D FFT
 kernel_ft = sp.fft.fft2(kernel, s=img.shape[:2], axes=(0, 1))
 
 # convolve

--- a/intro/scipy/examples/solutions/plot_periodicity_finder.py
+++ b/intro/scipy/examples/solutions/plot_periodicity_finder.py
@@ -34,8 +34,8 @@ plt.legend(["hare", "lynx", "carrot"], loc=1)
 ############################################################
 import scipy as sp
 
-ft_populations = sp.fftpack.fft(populations, axis=0)
-frequencies = sp.fftpack.fftfreq(populations.shape[0], years[1] - years[0])
+ft_populations = sp.fft.fft(populations, axis=0)
+frequencies = sp.fft.fftfreq(populations.shape[0], years[1] - years[0])
 periods = 1 / frequencies
 
 plt.figure()

--- a/intro/scipy/index.rst
+++ b/intro/scipy/index.rst
@@ -50,7 +50,7 @@ SciPy : high-level scientific computing
 =========================== ==========================================
 :mod:`scipy.cluster`         Vector quantization / Kmeans
 :mod:`scipy.constants`       Physical and mathematical constants
-:mod:`scipy.fftpack`         Fourier transform
+:mod:`scipy.fft`         Fourier transform
 :mod:`scipy.integrate`       Integration routines
 :mod:`scipy.interpolate`     Interpolation
 :mod:`scipy.io`              Data input and output
@@ -859,25 +859,25 @@ Integration of the system follows::
 .. _fipy: https://www.ctcms.nist.gov/fipy/
 .. _SfePy: https://sfepy.org/doc/
 
-Fast Fourier transforms: :mod:`scipy.fftpack`
+Fast Fourier transforms: :mod:`scipy.fft`
 ---------------------------------------------
 
-The :mod:`scipy.fftpack` module computes fast Fourier transforms (FFTs)
-and offers utilities to handle them. The main functions are:
+The :mod:`scipy.fft` module computes fast Fourier transforms (FFTs)
+and offers utilities to handle them. Some important functions are:
 
-* :func:`scipy.fftpack.fft` to compute the FFT
+* :func:`scipy.fft.fft` to compute the FFT
 
-* :func:`scipy.fftpack.fftfreq` to generate the sampling frequencies
+* :func:`scipy.fft.fftfreq` to generate the sampling frequencies
 
-* :func:`scipy.fftpack.ifft` computes the inverse FFT, from frequency
+* :func:`scipy.fft.ifft` to compute the inverse FFT, from frequency
   space to signal space
 
 |
 
 As an illustration, a (noisy) input signal (``sig``), and its FFT::
 
-    >>> sig_fft = sp.fftpack.fft(sig) # doctest:+SKIP
-    >>> freqs = sp.fftpack.fftfreq(sig.size, d=time_step) # doctest:+SKIP
+    >>> sig_fft = sp.fft.fft(sig)  # doctest:+SKIP
+    >>> freqs = sp.fft.fftfreq(sig.size, d=time_step)  # doctest:+SKIP
 
 
 .. |signal_fig| image:: auto_examples/images/sphx_glr_plot_fftpack_001.png
@@ -894,7 +894,7 @@ As an illustration, a (noisy) input signal (``sig``), and its FFT::
 **Signal**            **FFT**
 ===================== =====================
 
-As the signal comes from a real function, the Fourier transform is
+As the signal comes from a real-valued function, the Fourier transform is
 symmetric.
 
 The peak signal frequency can be found with ``freqs[power.argmax()]``
@@ -905,8 +905,8 @@ The peak signal frequency can be found with ``freqs[power.argmax()]``
     :align: right
 
 
-Setting the Fourrier component above this frequency to zero and inverting
-the FFT with :func:`scipy.fftpack.ifft`, gives a filtered signal.
+Setting the Fourier component above this frequency to zero and inverting
+the FFT with :func:`scipy.fft.ifft`, gives a filtered signal.
 
 .. note::
 
@@ -951,7 +951,7 @@ Crude periodicity finding (:ref:`link <sphx_glr_intro_scipy_auto_examples_soluti
 
    2. Load the image using :func:`matplotlib.pyplot.imread`.
 
-   3. Find and use the 2-D FFT function in :mod:`scipy.fftpack`, and plot the
+   3. Find and use the 2-D FFT function in :mod:`scipy.fft`, and plot the
       spectrum (Fourier transform of) the image. Do you have any trouble
       visualising the spectrum? If so, why?
 


### PR DESCRIPTION
`scipy.fftpack` is considered legacy; this updates uses of `scipy.fftpack` to use `scipy.fft`, instead. To avoid unnecessary churn, I didn't modify filenames that include `fftpack`. 