### PR TITLE
MAINT: use random Generator instead of RandomState

### DIFF
--- a/advanced/debugging/to_debug.py
+++ b/advanced/debugging/to_debug.py
@@ -16,6 +16,7 @@ from itertools import product
 
 import numpy as np
 import scipy as sp
+
 rng = np.random.default_rng(27446968)
 
 FUNCTIONS = (

--- a/advanced/debugging/to_debug.py
+++ b/advanced/debugging/to_debug.py
@@ -16,6 +16,7 @@ from itertools import product
 
 import numpy as np
 import scipy as sp
+rng = np.random.default_rng(27446968)
 
 FUNCTIONS = (
     np.tan,  # Dilating map
@@ -52,8 +53,8 @@ def compare_optimizers(optimizers):
     functions all admitting a single root in zero and a upper and
     lower bounds.
     """
-    random_a = -1.3 + np.random.random(size=100)
-    random_b = 0.3 + np.random.random(size=100)
+    random_a = -1.3 + rng.random(size=100)
+    random_b = 0.3 + rng.random(size=100)
     param_grid = product(FUNCTIONS, random_a, random_b)
     print("Benching 1D root-finder optimizers from scipy.optimize:")
     for optimizer in OPTIMIZERS:

--- a/advanced/debugging/to_debug_solution.py
+++ b/advanced/debugging/to_debug_solution.py
@@ -16,6 +16,7 @@ from itertools import product
 
 import numpy as np
 import scipy as sp
+
 rng = np.random.default_rng(27446968)
 
 FUNCTIONS = (

--- a/advanced/debugging/to_debug_solution.py
+++ b/advanced/debugging/to_debug_solution.py
@@ -16,6 +16,7 @@ from itertools import product
 
 import numpy as np
 import scipy as sp
+rng = np.random.default_rng(27446968)
 
 FUNCTIONS = (
     np.tan,  # Dilating map
@@ -52,8 +53,8 @@ def compare_optimizers(optimizers):
     functions all admitting a single root in zero and a upper and
     lower bounds.
     """
-    random_a = -1.3 + np.random.random(size=100)
-    random_b = 0.3 + np.random.random(size=100)
+    random_a = -1.3 + rng.random(size=100)
+    random_b = 0.3 + rng.random(size=100)
     param_grid = product(FUNCTIONS, random_a, random_b)
     values = []
     for value in param_grid:

--- a/advanced/debugging/wiener_filtering.py
+++ b/advanced/debugging/wiener_filtering.py
@@ -46,7 +46,7 @@ cut = (slice(128, -128), slice(128, -128))
 rng = np.random.default_rng(27446968)
 
 face = sp.datasets.face(gray=True)
-noisy_face = face + 20 * np.random.randint(3, size=face.shape) - 30
+noisy_face = face + 20 * rng.integers(3, size=face.shape) - 30
 
 plt.matshow(face[cut], cmap=plt.cm.gray)
 plt.matshow(noisy_face[cut], cmap=plt.cm.gray)

--- a/advanced/image_processing/examples/plot_GMM.py
+++ b/advanced/image_processing/examples/plot_GMM.py
@@ -17,14 +17,14 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 
 mask = (im > im.mean()).astype(float)
 
 
-img = mask + 0.3 * np.random.randn(*mask.shape)
+img = mask + 0.3 * rng.normal(size=mask.shape)
 
 hist, bin_edges = np.histogram(img, bins=60)
 bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])

--- a/advanced/image_processing/examples/plot_clean_morpho.py
+++ b/advanced/image_processing/examples/plot_clean_morpho.py
@@ -15,14 +15,14 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 
 mask = (im > im.mean()).astype(float)
 
 
-img = mask + 0.3 * np.random.randn(*mask.shape)
+img = mask + 0.3 * rng.normal(size=mask.shape)
 
 binary_img = img > 0.5
 

--- a/advanced/image_processing/examples/plot_denoising.py
+++ b/advanced/image_processing/examples/plot_denoising.py
@@ -10,10 +10,12 @@ import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
 
+rng = np.random.default_rng(27446968)
+
 im = np.zeros((20, 20))
 im[5:-5, 5:-5] = 1
 im = sp.ndimage.distance_transform_bf(im)
-im_noise = im + 0.2 * np.random.randn(*im.shape)
+im_noise = im + 0.2 * rng.normal(size=im.shape)
 
 im_med = sp.ndimage.median_filter(im_noise, 3)
 

--- a/advanced/image_processing/examples/plot_face_denoise.py
+++ b/advanced/image_processing/examples/plot_face_denoise.py
@@ -9,10 +9,12 @@ import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
 
+rng = np.random.default_rng(27446968)
+
 f = sp.datasets.face(gray=True)
 f = f[230:290, 220:320]
 
-noisy = f + 0.4 * f.std() * np.random.random(f.shape)
+noisy = f + 0.4 * f.std() * rng.random(f.shape)
 
 gauss_denoised = sp.ndimage.gaussian_filter(noisy, 2)
 med_denoised = sp.ndimage.median_filter(noisy, 3)

--- a/advanced/image_processing/examples/plot_face_tv_denoise.py
+++ b/advanced/image_processing/examples/plot_face_tv_denoise.py
@@ -11,10 +11,12 @@ import matplotlib.pyplot as plt
 
 from skimage.restoration import denoise_tv_chambolle
 
+rng = np.random.default_rng(27446968)
+
 f = sp.datasets.face(gray=True)
 f = f[230:290, 220:320]
 
-noisy = f + 0.4 * f.std() * np.random.random(f.shape)
+noisy = f + 0.4 * f.std() * rng.random(f.shape)
 
 tv_denoised = denoise_tv_chambolle(noisy, weight=10)
 

--- a/advanced/image_processing/examples/plot_find_edges.py
+++ b/advanced/image_processing/examples/plot_find_edges.py
@@ -9,6 +9,8 @@ import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
 
+rng = np.random.default_rng(27446968)
+
 im = np.zeros((256, 256))
 im[64:-64, 64:-64] = 1
 
@@ -33,7 +35,7 @@ plt.imshow(sob)
 plt.axis("off")
 plt.title("Sobel filter", fontsize=20)
 
-im += 0.07 * np.random.random(im.shape)
+im += 0.07 * rng.random(im.shape)
 
 sx = sp.ndimage.sobel(im, axis=0, mode="constant")
 sy = sp.ndimage.sobel(im, axis=1, mode="constant")

--- a/advanced/image_processing/examples/plot_find_object.py
+++ b/advanced/image_processing/examples/plot_find_object.py
@@ -14,7 +14,7 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 

--- a/advanced/image_processing/examples/plot_granulo.py
+++ b/advanced/image_processing/examples/plot_granulo.py
@@ -33,7 +33,7 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 

--- a/advanced/image_processing/examples/plot_greyscale_dilation.py
+++ b/advanced/image_processing/examples/plot_greyscale_dilation.py
@@ -10,8 +10,8 @@ import scipy as sp
 import matplotlib.pyplot as plt
 
 im = np.zeros((64, 64))
-np.random.seed(2)
-x, y = (63 * np.random.random((2, 8))).astype(int)
+rng = np.random.default_rng(27446968)
+x, y = (63 * rng.random((2, 8))).astype(int)
 im[x, y] = np.arange(8)
 
 bigger_points = sp.ndimage.grey_dilation(im, size=(5, 5), structure=np.ones((5, 5)))

--- a/advanced/image_processing/examples/plot_histo_segmentation.py
+++ b/advanced/image_processing/examples/plot_histo_segmentation.py
@@ -13,7 +13,7 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 
@@ -21,7 +21,7 @@ mask = (im > im.mean()).astype(float)
 
 mask += 0.1 * im
 
-img = mask + 0.2 * np.random.randn(*mask.shape)
+img = mask + 0.2 * rng.normal(size=mask.shape)
 
 hist, bin_edges = np.histogram(img, bins=60)
 bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])

--- a/advanced/image_processing/examples/plot_measure_data.py
+++ b/advanced/image_processing/examples/plot_measure_data.py
@@ -14,7 +14,7 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 

--- a/advanced/image_processing/examples/plot_propagation.py
+++ b/advanced/image_processing/examples/plot_propagation.py
@@ -11,8 +11,8 @@ import matplotlib.pyplot as plt
 
 square = np.zeros((32, 32))
 square[10:-10, 10:-10] = 1
-np.random.seed(2)
-x, y = (32 * np.random.random((2, 20))).astype(int)
+rng = np.random.default_rng(27446968)
+x, y = (32 * rng.random((2, 20))).astype(int)
 square[x, y] = 1
 
 open_square = sp.ndimage.binary_opening(square)

--- a/advanced/image_processing/examples/plot_spectral_clustering.py
+++ b/advanced/image_processing/examples/plot_spectral_clustering.py
@@ -33,7 +33,8 @@ img = circle1 + circle2 + circle3 + circle4
 mask = img.astype(bool)
 img = img.astype(float)
 
-img += 1 + 0.2 * np.random.randn(*img.shape)
+rng = np.random.default_rng(27446968)
+img += 1 + 0.2 * rng.normal(size=img.shape)
 
 # Convert the image into a graph with the value of the gradient on the
 # edges.

--- a/advanced/image_processing/examples/plot_synthetic_data.py
+++ b/advanced/image_processing/examples/plot_synthetic_data.py
@@ -13,7 +13,7 @@ rng = np.random.default_rng(27446968)
 n = 10
 l = 256
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = sp.ndimage.gaussian_filter(im, sigma=l / (4.0 * n))
 

--- a/advanced/mathematical_optimization/examples/helper/compare_optimizers.py
+++ b/advanced/mathematical_optimization/examples/helper/compare_optimizers.py
@@ -95,8 +95,8 @@ def mk_costs(ndim=2):
         "Rosenbrock  ": (rosenbrock, rosenbrock_prime, rosenbrock_hessian),
     }
 
-    rng = np.random.RandomState(0)
-    starting_points = 4 * rng.rand(20, ndim) - 2
+    rng = np.random.default_rng(5982345892)
+    starting_points = 4 * rng.random((20, ndim)) - 2
     if ndim > 100:
         starting_points = starting_points[:10]
     return costs, starting_points

--- a/intro/matplotlib/examples/pretty_plots/plot_text_ext.py
+++ b/intro/matplotlib/examples/pretty_plots/plot_text_ext.py
@@ -26,11 +26,11 @@ eqs.append(r"$F_G = G\frac{m_1m_2}{r^2}$")
 rng = np.random.default_rng()
 
 for i in range(24):
-    index = np.random.randint(0, len(eqs))
+    index = rng.integers(0, len(eqs))
     eq = eqs[index]
-    size = np.random.uniform(12, 32)
-    x, y = np.random.uniform(0, 1, 2)
-    alpha = np.random.uniform(0.25, 0.75)
+    size = rng.uniform(12, 32)
+    x, y = rng.uniform(0, 1, 2)
+    alpha = rng.uniform(0.25, 0.75)
     plt.text(
         x,
         y,

--- a/intro/numpy/examples/plot_chebyfit.py
+++ b/intro/numpy/examples/plot_chebyfit.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 rng = np.random.default_rng(27446968)
 
 x = np.linspace(-1, 1, 2000)
-y = np.cos(x) + 0.3 * np.random.rand(2000)
+y = np.cos(x) + 0.3 * rng.random(2000)
 p = np.polynomial.Chebyshev.fit(x, y, 90)
 
 plt.plot(x, y, "r.")

--- a/intro/numpy/examples/plot_polyfit.py
+++ b/intro/numpy/examples/plot_polyfit.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 rng = np.random.default_rng(27446968)
 
 x = np.linspace(0, 1, 20)
-y = np.cos(x) + 0.3 * np.random.rand(20)
+y = np.cos(x) + 0.3 * rng.random(20)
 p = np.poly1d(np.polyfit(x, y, 3))
 
 t = np.linspace(0, 1, 200)

--- a/intro/scipy/examples/plot_fftpack.py
+++ b/intro/scipy/examples/plot_fftpack.py
@@ -28,7 +28,7 @@ time_step = 0.02
 period = 5.0
 
 time_vec = np.arange(0, 20, time_step)
-sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * np.random.randn(time_vec.size)
+sig = np.sin(2 * np.pi / period * time_vec) + 0.5 * rng.normal(size=time_vec.size)
 
 plt.figure(figsize=(6, 5))
 plt.plot(time_vec, sig, label="Original signal")

--- a/intro/scipy/examples/plot_interpolation.py
+++ b/intro/scipy/examples/plot_interpolation.py
@@ -8,9 +8,9 @@ A demo of 1D interpolation
 # Generate data
 import numpy as np
 
-np.random.seed(0)
+rng = np.random.default_rng(27446968)
 measured_time = np.linspace(0, 1, 10)
-noise = 1e-1 * (np.random.random(10) * 2 - 1)
+noise = 1e-1 * (rng.random(10) * 2 - 1)
 measures = np.sin(2 * np.pi * measured_time) + noise
 
 # Interpolate it to new time points

--- a/packages/scikit-image/examples/plot_labels.py
+++ b/packages/scikit-image/examples/plot_labels.py
@@ -15,7 +15,7 @@ n = 12
 l = 256
 rng = np.random.default_rng(27446968)
 im = np.zeros((l, l))
-points = l * np.random.random((2, n**2))
+points = l * rng.random((2, n**2))
 im[(points[0]).astype(int), (points[1]).astype(int)] = 1
 im = filters.gaussian(im, sigma=l / (4.0 * n))
 blobs = im > 0.7 * im.mean()

--- a/packages/scikit-learn/examples/plot_polynomial_regression.py
+++ b/packages/scikit-learn/examples/plot_polynomial_regression.py
@@ -18,8 +18,8 @@ cmap_light = ListedColormap(["#FFAAAA", "#AAFFAA", "#AAAAFF"])
 cmap_bold = ListedColormap(["#FF0000", "#00FF00", "#0000FF"])
 
 
-rng = np.random.RandomState(0)
-x = 2 * rng.rand(100) - 1
+rng = np.random.default_rng(27446968)
+x = 2 * rng.random(100) - 1
 
 f = lambda t: 1.2 * t**2 + 0.1 * t**3 - 0.4 * t**5 - 0.5 * t**9
 y = f(x) + 0.4 * rng.normal(size=100)

--- a/packages/scikit-learn/examples/plot_svm_non_linear.py
+++ b/packages/scikit-learn/examples/plot_svm_non_linear.py
@@ -66,8 +66,10 @@ ax.contour(
 # data with a non-linear separation
 
 
-def nonlinear_model(rseed=42, n_samples=30):
-    radius = 40 * np.random.random(n_samples)
+def nonlinear_model(rseed=27446968, n_samples=30):
+    rng = np.random.default_rng(rseed)
+
+    radius = 40 * rng.random(n_samples)
     far_pts = radius > 20
     radius[far_pts] *= 1.2
     radius[~far_pts] *= 1.1


### PR DESCRIPTION
It looks like the intent was to switch from use of `RandomState`s to `Generator`s, but the transition is incomplete. I searched for occurences of `random.rand` (which also finds `randn` and `randint`) and replaced them.

@tupui would you check me here? Some things to look for:
- `rng` is defined where it's used
- `rng` is defined only once (i.e. I didn't add it a new one where it was unneeded)
- `random.rand` with separate positional arguments has been replaced with `rng.random` with single positional argument
- `random.randn` with a positional arguments has been changed to `rng.normal` with `size` keyword argument, etc.
- `random.randint` has been replaced with `rng.integers` (signatures are compatible, right?)
- I didn't miss anything obvious?