### PR TITLE
Fix repr changes in sparse for Scipy 1.14

### DIFF
--- a/advanced/scipy_sparse/bsr_array.rst
+++ b/advanced/scipy_sparse/bsr_array.rst
@@ -35,8 +35,8 @@ Examples
 
     >>> mtx = sp.sparse.bsr_array((3, 4), dtype=np.int8)
     >>> mtx
-    <3x4 sparse array of type '<... 'numpy.int8'>'
-            with 0 stored elements (blocksize = 1x1) in Block Sparse Row format>
+    <Block Sparse Row sparse array of dtype 'int8'
+            with 0 stored elements (blocksize=1x1) and shape (3, 4)>
     >>> mtx.toarray()
     array([[0, 0, 0, 0],
            [0, 0, 0, 0],
@@ -46,8 +46,8 @@ Examples
 
     >>> mtx = sp.sparse.bsr_array((3, 4), blocksize=(3, 2), dtype=np.int8)
     >>> mtx
-    <3x4 sparse array of type '<... 'numpy.int8'>'
-            with 0 stored elements (blocksize = 3x2) in Block Sparse Row format>
+    <Block Sparse Row sparse array of dtype 'int8'
+            with 0 stored elements (blocksize=3x2) and shape (3, 4)>
     >>> mtx.toarray()
     array([[0, 0, 0, 0],
            [0, 0, 0, 0],
@@ -62,8 +62,8 @@ Examples
     >>> data = np.array([1, 2, 3, 4, 5, 6])
     >>> mtx = sp.sparse.bsr_array((data, (row, col)), shape=(3, 3))
     >>> mtx
-    <3x3 sparse array of type '<... 'numpy.int64'>'
-            with 6 stored elements (blocksize = 1x1) in Block Sparse Row format>
+    <Block Sparse Row sparse array of dtype 'int64'
+            with 6 stored elements (blocksize=1x1) and shape (3, 3)>
     >>> mtx.toarray()
     array([[1, 0, 2],
            [0, 0, 3],

--- a/advanced/scipy_sparse/coo_array.rst
+++ b/advanced/scipy_sparse/coo_array.rst
@@ -49,8 +49,8 @@ Examples
     >>> data = np.array([4, 5, 7, 9])
     >>> mtx = sp.sparse.coo_array((data, (row, col)), shape=(4, 4))
     >>> mtx
-    <4x4 sparse array of type '<... 'numpy.int64'>'
-            with 4 stored elements in COOrdinate format>
+    <COOrdinate sparse array of dtype 'int64'
+            with 4 stored elements and shape (4, 4)>
     >>> mtx.toarray()
     array([[4, 0, 9, 0],
            [0, 7, 0, 0],

--- a/advanced/scipy_sparse/csc_array.rst
+++ b/advanced/scipy_sparse/csc_array.rst
@@ -50,8 +50,8 @@ Examples
     >>> data = np.array([1, 2, 3, 4, 5, 6])
     >>> mtx = sp.sparse.csc_array((data, (row, col)), shape=(3, 3))
     >>> mtx
-    <3x3 sparse array of type '<... 'numpy.int64'>'
-            with 6 stored elements in Compressed Sparse Column format>
+    <Compressed Sparse Column sparse array of dtype 'int64'
+            with 6 stored elements and shape (3, 3)>
     >>> mtx.toarray()
     array([[1, 0, 2],
            [0, 0, 3],

--- a/advanced/scipy_sparse/csr_array.rst
+++ b/advanced/scipy_sparse/csr_array.rst
@@ -49,8 +49,8 @@ Examples
     >>> data = np.array([1, 2, 3, 4, 5, 6])
     >>> mtx = sp.sparse.csr_array((data, (row, col)), shape=(3, 3))
     >>> mtx
-    <3x3 sparse array of type '<... 'numpy.int64'>'
-            with 6 stored elements in Compressed Sparse Row format>
+    <Compressed Sparse Row sparse array of dtype 'int64'
+            with 6 stored elements and shape (3, 3)>
     >>> mtx.toarray()
     array([[1, 0, 2],
            [0, 0, 3],

--- a/advanced/scipy_sparse/dia_array.rst
+++ b/advanced/scipy_sparse/dia_array.rst
@@ -43,7 +43,7 @@ Examples
     >>> mtx = sp.sparse.dia_array((data, offsets), shape=(4, 4))
     >>> mtx
     <DIAgonal sparse array of dtype 'int64'
-            with 9 stored elements and shape (4, 4)>
+        with 9 stored elements (3 diagonals) and shape (4, 4)>
     >>> mtx.toarray()
     array([[1, 0, 3, 0],
            [1, 2, 0, 4],
@@ -63,15 +63,18 @@ Examples
     >>> mtx.offsets
     array([ 0, -1,  2], dtype=int32)
     >>> print(mtx)
-    (np.int32(0), np.int32(0))	1
-    (np.int32(1), np.int32(1))	2
-    (np.int32(2), np.int32(2))	3
-    (np.int32(3), np.int32(3))	4
-    (np.int32(1), np.int32(0))	5
-    (np.int32(2), np.int32(1))	6
-    (np.int32(3), np.int32(2))	7
-    (np.int32(0), np.int32(2))	11
-    (np.int32(1), np.int32(3))	12
+    <DIAgonal sparse array of dtype 'int64'
+        with 9 stored elements (3 diagonals) and shape (4, 4)>
+      Coords    Values
+      (0, 0)	1
+      (1, 1)	2
+      (2, 2)	3
+      (3, 3)	4
+      (1, 0)	5
+      (2, 1)	6
+      (3, 2)	7
+      (0, 2)	11
+      (1, 3)	12
     >>> mtx.toarray()
     array([[ 1,  0, 11,  0],
            [ 5,  2,  0, 12],

--- a/advanced/scipy_sparse/dia_array.rst
+++ b/advanced/scipy_sparse/dia_array.rst
@@ -42,8 +42,8 @@ Examples
     >>> offsets = np.array([0, -1, 2])
     >>> mtx = sp.sparse.dia_array((data, offsets), shape=(4, 4))
     >>> mtx
-    <4x4 sparse array of type '<... 'numpy.int64'>'
-            with 9 stored elements (3 diagonals) in DIAgonal format>
+    <DIAgonal sparse array of dtype 'int64'
+            with 9 stored elements and shape (4, 4)>
     >>> mtx.toarray()
     array([[1, 0, 3, 0],
            [1, 2, 0, 4],

--- a/advanced/scipy_sparse/dok_array.rst
+++ b/advanced/scipy_sparse/dok_array.rst
@@ -28,14 +28,14 @@ Examples
 
     >>> mtx = sp.sparse.dok_array((5, 5), dtype=np.float64)
     >>> mtx
-    <5x5 sparse array of type '<... 'numpy.float64'>'
-            with 0 stored elements in Dictionary Of Keys format>
+    <Dictionary Of Keys sparse array of dtype 'float64'
+            with 0 stored elements and shape (5, 5)>
     >>> for ir in range(5):
     ...     for ic in range(5):
     ...         mtx[ir, ic] = 1.0 * (ir != ic)
     >>> mtx
-    <5x5 sparse array of type '<... 'numpy.float64'>'
-            with 20 stored elements in Dictionary Of Keys format>
+    <Dictionary Of Keys sparse array of dtype 'float64'
+            with 20 stored elements and shape (5, 5)>
     >>> mtx.toarray()
     array([[0.,  1.,  1.,  1.,  1.],
            [1.,  0.,  1.,  1.,  1.],
@@ -48,8 +48,8 @@ Examples
     >>> mtx[1, 1]
     np.float64(0.0)
     >>> mtx[[1], 1:3]
-    <1x2 sparse array of type '<... 'numpy.float64'>'
-          with 1 stored elements in Dictionary Of Keys format>
+    <Dictionary Of Keys sparse array of dtype 'float64'
+            with 1 stored elements and shape (1, 2)>
     >>> mtx[[1], 1:3].toarray()
     array([[0.,  1.]])
     >>> mtx[[2, 1], 1:3].toarray()

--- a/advanced/scipy_sparse/dok_array.rst
+++ b/advanced/scipy_sparse/dok_array.rst
@@ -46,7 +46,7 @@ Examples
 * slicing and indexing::
 
     >>> mtx[1, 1]
-    0.0
+    np.float64(0.0)
     >>> mtx[[1], 1:3]
     <Dictionary Of Keys sparse array of dtype 'float64'
             with 1 stored elements and shape (1, 2)>

--- a/advanced/scipy_sparse/dok_array.rst
+++ b/advanced/scipy_sparse/dok_array.rst
@@ -46,7 +46,7 @@ Examples
 * slicing and indexing::
 
     >>> mtx[1, 1]
-    np.float64(0.0)
+    0.0
     >>> mtx[[1], 1:3]
     <Dictionary Of Keys sparse array of dtype 'float64'
             with 1 stored elements and shape (1, 2)>

--- a/advanced/scipy_sparse/lil_array.rst
+++ b/advanced/scipy_sparse/lil_array.rst
@@ -42,6 +42,9 @@ Examples
     <List of Lists sparse array of dtype 'float64'
             with 3 stored elements and shape (4, 5)>
     >>> print(mtx)
+    <List of Lists sparse array of dtype 'float64'
+            with 3 stored elements and shape (4, 5)>
+      Coords    Values
       (0, 1)    1.0
       (0, 3)    1.0
       (1, 3)    1.0
@@ -64,6 +67,9 @@ Examples
            [3, 0, 1, 0],
            [1, 0, 0, 1]]...)
     >>> print(mtx)
+    <List of Lists sparse array of dtype 'int64'
+            with 6 stored elements and shape (3, 4)>
+      Coords    Values
       (0, 1)    1
       (0, 2)    2
       (1, 0)    3

--- a/advanced/scipy_sparse/lil_array.rst
+++ b/advanced/scipy_sparse/lil_array.rst
@@ -39,8 +39,8 @@ Examples
 
     >>> mtx[:2, [1, 2, 3]] = data
     >>> mtx
-    <4x5 sparse array of type '<... 'numpy.float64'>'
-            with 3 stored elements in List of Lists format>
+    <List of Lists sparse array of dtype 'float64'
+            with 3 stored elements and shape (4, 5)>
     >>> print(mtx)
       (0, 1)    1.0
       (0, 3)    1.0
@@ -71,8 +71,8 @@ Examples
       (2, 0)    1
       (2, 3)    1
     >>> mtx[:2, :]
-    <2x4 sparse array of type '<... 'numpy.int64'>'
-      with 4 stored elements in List of Lists format>
+    <List of Lists sparse array of dtype 'int64'
+            with 4 stored elements and shape (2, 4)>
     >>> mtx[:2, :].toarray()
     array([[0, 1, 2, 0],
            [3, 0, 1, 0]]...)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.0.0
-scipy==1.13.1
+scipy==1.14.0
 matplotlib==3.9.0
 pandas==2.2.2
 patsy==0.5.6


### PR DESCRIPTION
I added the other repr changes for scipy 1.14 in the scipy-sparse lectures. hopefully the tests are green