### PR TITLE
Fix LOBPCG Sakurai typos

### DIFF
--- a/advanced/scipy_sparse/examples/direct_solve.py
+++ b/advanced/scipy_sparse/examples/direct_solve.py
@@ -15,7 +15,7 @@ rng = np.random.default_rng(27446968)
 
 mtx = sp.sparse.lil_array((1000, 1000), dtype=np.float64)
 mtx[0, :100] = rng.random(100)
-mtx[1, 100:200] = mtx[0, :100]
+mtx[1, 100:200] = mtx[[0], :100]
 mtx.setdiag(rng.random(1000))
 
 plt.clf()
@@ -27,4 +27,4 @@ rhs = rng.random(1000)
 
 x = sp.sparse.linalg.spsolve(mtx, rhs)
 
-print(f"residual: {np.linalg.norm(mtx * x - rhs)!r}")
+print(f"residual: {np.linalg.norm(mtx @ x - rhs)!r}")

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -45,7 +45,13 @@ X = np.random.random((n, m))
 data = []
 tt = time.time()
 eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
-    A, X, B, tol=1e-6, largest=False, maxiter=500, retResidualNormsHistory=1,
+    A,
+    X,
+    B,
+    tol=1e-6,
+    largest=False,
+    maxiter=500,
+    retResidualNormsHistory=1,
 )
 data.append(time.time() - tt)
 print("Results by LOBPCG for n=" + str(n))

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -45,7 +45,7 @@ X = np.random.random((n, m))
 data = []
 tt = time.time()
 eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
-    A, X, B, tol=1e-6, maxiter=500, retResidualNormsHistory=1
+    A, X, B, tol=1e-6, largest=False, maxiter=500, retResidualNormsHistory=1,
 )
 data.append(time.time() - tt)
 print("Results by LOBPCG for n=" + str(n))

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -21,7 +21,7 @@ def sakurai(n):
     """
 
     A = sp.sparse.eye(n, n)
-    d0 = np.r_[5, 6 * np.ones(n - 2), 5]
+    d0 = np.hstack([5, 6 * np.ones(n - 2), 5])
     d1 = -4 * np.ones(n)
     d2 = np.ones(n)
     B = sp.sparse.spdiags([d2, d1, d0, d1, d2], [-2, -1, 0, 1, 2], n, n)
@@ -41,13 +41,13 @@ m = 3  # Blocksize
 #
 n = 2500
 A, B, w_ex = sakurai(n)  # Mikota pair
-X = np.random.rand(n, m)
+X = np.random.random((n, m))
 data = []
-tt = time.process_time()
+tt = time.time()
 eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
     A, X, B, tol=1e-6, maxiter=500, retResidualNormsHistory=1
 )
-data.append(time.process_time() - tt)
+data.append(time.time() - tt)
 print("Results by LOBPCG for n=" + str(n))
 print()
 print(eigs)

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -50,7 +50,7 @@ eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
     B,
     tol=1e-6,
     largest=False,
-    maxiter=500,
+    maxiter=2000,
     retResidualNormsHistory=1,
 )
 data.append(time.time() - tt)

--- a/advanced/scipy_sparse/examples/lobpcg_sakurai.py
+++ b/advanced/scipy_sparse/examples/lobpcg_sakurai.py
@@ -21,7 +21,7 @@ def sakurai(n):
     """
 
     A = sp.sparse.eye(n, n)
-    d0 = np.array(r_[5, 6 * ones(n - 2), 5])
+    d0 = np.r_[5, 6 * np.ones(n - 2), 5]
     d1 = -4 * np.ones(n)
     d2 = np.ones(n)
     B = sp.sparse.spdiags([d2, d1, d0, d1, d2], [-2, -1, 0, 1, 2], n, n)
@@ -41,13 +41,13 @@ m = 3  # Blocksize
 #
 n = 2500
 A, B, w_ex = sakurai(n)  # Mikota pair
-X = np.rand(n, m)
+X = np.random.rand(n, m)
 data = []
-tt = time.clock()
+tt = time.process_time()
 eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
     A, X, B, tol=1e-6, maxiter=500, retResidualNormsHistory=1
 )
-data.append(time.clock() - tt)
+data.append(time.process_time() - tt)
 print("Results by LOBPCG for n=" + str(n))
 print()
 print(eigs)

--- a/advanced/scipy_sparse/examples/pyamg_with_lobpcg.py
+++ b/advanced/scipy_sparse/examples/pyamg_with_lobpcg.py
@@ -7,6 +7,7 @@ the LOBPCG eigensolver on a two-dimensional Poisson problem with
 Dirichlet boundary conditions.
 """
 
+import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt
 
@@ -21,7 +22,7 @@ A = poisson((N, N), format="csr")
 ml = smoothed_aggregation_solver(A)
 
 # initial approximation to the K eigenvectors
-X = sp.rand(A.shape[0], K)
+X = np.random.random((A.shape[0], K))
 
 # preconditioner based on ml
 M = ml.aspreconditioner()


### PR DESCRIPTION
Still needs work (but it runs now):
```
$ python advanced/scipy_sparse/examples/lobpcg_sakurai.py
/home/jarrod/src/scientific-python-lectures/advanced/scipy_sparse/examples/lobpcg_sakurai.py:47: UserWarning: Exited at iteration 500 with accuracies 
[1158100.72206623    8047.95297708    6596.98347933]
not reaching the requested tolerance 1e-06.
Use iteration 0 instead with accuracy 
2.0908717846394285.

  eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
/home/jarrod/src/scientific-python-lectures/advanced/scipy_sparse/examples/lobpcg_sakurai.py:47: UserWarning: Exited postprocessing with accuracies 
[5.4496576  0.42115509 0.40180266]
not reaching the requested tolerance 1e-06.
  eigs, vecs, resnh = sp.sparse.linalg.lobpcg(
Results by LOBPCG for n=2500

[1.6384843  0.17288616 0.16788489]

Exact eigenvalues

[0.06250005 0.0625002  0.06250044]

Elapsed time 1.311448997
/home/jarrod/src/scientific-python-lectures/advanced/scipy_sparse/examples/lobpcg_sakurai.py:64: UserWarning: FigureCanvasAgg is non-interactive, and thus cannot be shown
  plt.show()
```

According to the notes, we should be seeing:
```
$ python examples/lobpcg_sakurai.py
Results by LOBPCG for n=2500

[ 0.06250083  0.06250028  0.06250007]

Exact eigenvalues

[ 0.06250005  0.0625002   0.06250044]

Elapsed time 7.01
```