### PR TITLE
Update scipy

### DIFF
--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -887,11 +887,10 @@ Lets try to minimize the norm of the following vectorial function::
     >>> x0 = np.zeros(10)
     >>> sp.optimize.leastsq(f, x0)
     (array([0.        , 0.11111111, 0.22222222, 0.33333333, 0.44444444,
-           0.55555556, 0.66666667, 0.77777778, 0.88888889, 1.        ]), 2)
+           0.55555556, 0.66666667, 0.77777778, 0.88888889, 1.        ]), ...)
 
-This took 67 function evaluations (check it with 'full_output=1'). What
-if we compute the norm ourselves and use a good generic optimizer
-(BFGS)::
+This took 67 function evaluations (check it with 'full_output=True'). What
+if we compute the norm ourselves and use a good generic optimizer (BFGS)::
 
     >>> def g(x):
     ...     return np.sum(f(x)**2)

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -957,7 +957,7 @@ support bound constraints with the parameter ``bounds``::
     >>> def f(x):
     ...    return np.sqrt((x[0] - 3)**2 + (x[1] - 2)**2)
     >>> sp.optimize.minimize(f, np.array([0, 0]), bounds=((-1.5, 1.5), (-1.5, 1.5)))
-      message: CONVERGENCE: NORM OF PROJECTED GRADIENT <=_PGTOL
+      message: CONVERGENCE: NORM OF PROJECTED GRADIENT <= PGTOL
       success: True
        status: 0
           fun: 1.5811388300841898

--- a/advanced/mathematical_optimization/index.rst
+++ b/advanced/mathematical_optimization/index.rst
@@ -613,16 +613,16 @@ are also supported by L-BFGS-B::
     >>> def jacobian(x):
     ...     return np.array((-2*.5*(1 - x[0]) - 4*x[0]*(x[1] - x[0]**2), 2*(x[1] - x[0]**2)))
     >>> sp.optimize.minimize(f, [2, 2], method="L-BFGS-B", jac=jacobian)
-     message: CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL
-     success: True
-      status: 0
-         fun: 1.4417677473...e-15
-           x: [ 1.000e+00  1.000e+00]
-         nit: 16
-         jac: [ 1.023e-07 -2.593e-08]
-        nfev: 17
-        njev: 17
-    hess_inv: <2x2 LbfgsInvHessProduct with dtype=float64>
+      message: CONVERGENCE: NORM OF PROJECTED GRADIENT <= PGTOL
+      success: True
+       status: 0
+          fun: 1.4417677473...e-15
+            x: [ 1.000e+00  1.000e+00]
+          nit: 16
+          jac: [ 1.023e-07 -2.593e-08]
+         nfev: 17
+         njev: 17
+     hess_inv: <2x2 LbfgsInvHessProduct with dtype=float64>
 
 Gradient-less methods
 ----------------------
@@ -886,8 +886,8 @@ Lets try to minimize the norm of the following vectorial function::
 
     >>> x0 = np.zeros(10)
     >>> sp.optimize.leastsq(f, x0)
-    (array([0.        ,  0.11111111,  0.22222222,  0.33333333,  0.44444444,
-            0.55555556,  0.66666667,  0.77777778,  0.88888889,  1.        ]), 2)
+    (array([0.        , 0.11111111, 0.22222222, 0.33333333, 0.44444444,
+           0.55555556, 0.66666667, 0.77777778, 0.88888889, 1.        ]), 2)
 
 This took 67 function evaluations (check it with 'full_output=1'). What
 if we compute the norm ourselves and use a good generic optimizer
@@ -958,7 +958,7 @@ support bound constraints with the parameter ``bounds``::
     >>> def f(x):
     ...    return np.sqrt((x[0] - 3)**2 + (x[1] - 2)**2)
     >>> sp.optimize.minimize(f, np.array([0, 0]), bounds=((-1.5, 1.5), (-1.5, 1.5)))
-      message: CONVERGENCE: NORM_OF_PROJECTED_GRADIENT_<=_PGTOL
+      message: CONVERGENCE: NORM OF PROJECTED GRADIENT <=_PGTOL
       success: True
        status: 0
           fun: 1.5811388300841898
@@ -967,7 +967,7 @@ support bound constraints with the parameter ``bounds``::
           jac: [-9.487e-01 -3.162e-01]
          nfev: 9
          njev: 3
-         hess_inv: <2x2 LbfgsInvHessProduct with dtype=float64>
+     hess_inv: <2x2 LbfgsInvHessProduct with dtype=float64>
 
 .. image:: auto_examples/images/sphx_glr_plot_constraints_002.png
     :target: auto_examples/plot_constraints.html

--- a/advanced/scipy_sparse/solvers.rst
+++ b/advanced/scipy_sparse/solvers.rst
@@ -150,7 +150,7 @@ LinearOperator Class
     ...
     >>> A = sp.sparse.linalg.LinearOperator((2, 2), matvec=mv)
     >>> A
-    <2x2 _CustomLinearOperator with dtype=float64>
+    <2x2 _CustomLinearOperator with dtype=int8>
     >>> A.matvec(np.ones(2))
     array([2.,  3.])
     >>> A * np.ones(2)

--- a/packages/statistics/index.rst
+++ b/packages/statistics/index.rst
@@ -365,7 +365,7 @@ will affect the conclusions of the test, we can use a `Wilcoxon signed-rank test
 this assumption at the expense of test power::
 
     >>> sp.stats.wilcoxon(data['VIQ'])
-    WilcoxonResult(statistic=np.float64(0.0), pvalue=np.float64(1.8189894...e-12))
+    WilcoxonResult(statistic=np.float64(0.0), pvalue=np.float64(3.4881726...e-08))
 
 Two-sample t-test: testing for difference across populations
 ............................................................

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==2.2.1
-scipy==1.14.1
+scipy==1.15.1
 matplotlib==3.10.0
 pandas==2.2.3
 patsy==1.0.1


### PR DESCRIPTION
@mdhaber We are getting this error with 1.15.0 and 1.15.1
```
367     >>> sp.stats.wilcoxon(data['VIQ'])
Expected:
    WilcoxonResult(statistic=np.float64(0.0), pvalue=np.float64(1.8189894...e-12))
Got:
    WilcoxonResult(statistic=np.float64(0.0), pvalue=np.float64(3.488172636231201e-08))

/home/runner/work/scientific-python-lectures/scientific-python-lectures/packages/statistics/index.rst:367: DocTestFailure
```

Thoughts?