### PR TITLE
Fix typo from ploints to points in plot_separator.py

### DIFF
--- a/packages/scikit-learn/examples/plot_separator.py
+++ b/packages/scikit-learn/examples/plot_separator.py
@@ -2,7 +2,7 @@
 Simple picture of the formal problem of machine learning
 =========================================================
 
-This example generates simple synthetic data ploints and shows a
+This example generates simple synthetic data points and shows a
 separating hyperplane on them.
 """
 


### PR DESCRIPTION
Fix typo from ploints to points in plot_separator.py.