### PR TITLE
Update index.rst 1.5.7.2 equation

### DIFF
--- a/intro/scipy/index.rst
+++ b/intro/scipy/index.rst
@@ -831,6 +831,7 @@ needs to be transformed into a system of first-order ODEs. Note that
 .. math::
 
     \frac{dy}{dt} = \dot{y}
+
     \frac{d\dot{y}}{dt} = \ddot{y} = -(2 \zeta \omega_0  \dot{y} + \omega_0^2 y)
 
 If we define :math:`z = [z_0, z_1]` where :math:`z_0 = y` and :math:`z_1 = \dot{y}`,


### PR DESCRIPTION
In 1.5.7.2. the equations dy/dy=... and dy_dot/dt=... are displayed connected side by side. I know nothing about git and text formatting so I've just put enter between equations.  


<img width="306" height="68" alt="1 5 SciPy error" src="https://github.com/user-attachments/assets/a2c2f457-dc09-4ede-8bb3-a2d0dc99f679" />
